### PR TITLE
Add support for Astro v2

### DIFF
--- a/.changeset/new-guests-argue.md
+++ b/.changeset/new-guests-argue.md
@@ -1,0 +1,5 @@
+---
+'astro-og-canvas': patch
+---
+
+Allow installation in Astro v2 projects

--- a/package-lock.json
+++ b/package-lock.json
@@ -8763,7 +8763,7 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "astro": "^1.0.0"
+        "astro": "^1.0.0 || ^2.0.0-beta"
       }
     },
     "packages/astro-og-canvas/node_modules/@types/node": {

--- a/packages/astro-og-canvas/package.json
+++ b/packages/astro-og-canvas/package.json
@@ -39,7 +39,7 @@
     "entities": "^4.4.0"
   },
   "peerDependencies": {
-    "astro": "^1.0.0"
+    "astro": "^1.0.0 || ^2.0.0-beta"
   },
   "engines": {
     "node": ">=16.0.0"


### PR DESCRIPTION
Updates `package.json` to allow Astro v2 (incl beta) as peer dependency.

Tested install and that png generates as expected in a Astro v2.0.0-beta.2 project.

Fix #8 