### PR TITLE
Fix unexpected slug truncation for paths without extension

### DIFF
--- a/.changeset/metal-queens-brush.md
+++ b/.changeset/metal-queens-brush.md
@@ -1,0 +1,5 @@
+---
+"astro-og-canvas": patch
+---
+
+Fix unexpected slug truncation for paths without extension

--- a/packages/astro-og-canvas/src/routing.ts
+++ b/packages/astro-og-canvas/src/routing.ts
@@ -4,8 +4,7 @@ import type { OGImageOptions } from './types';
 
 const pathToSlug = (path: string): string => {
   path = path.replace(/^\/src\/pages\//, '');
-  const extIndex = path.lastIndexOf('.');
-  path = path.slice(0, extIndex) + '.png';
+  path = path.replace(/\..*$/, '') + '.png';
   path = path.replace(/\/index\.png$/, '.png');
   return path;
 };

--- a/packages/astro-og-canvas/src/routing.ts
+++ b/packages/astro-og-canvas/src/routing.ts
@@ -4,7 +4,7 @@ import type { OGImageOptions } from './types';
 
 const pathToSlug = (path: string): string => {
   path = path.replace(/^\/src\/pages\//, '');
-  path = path.replace(/\..*$/, '') + '.png';
+  path = path.replace(/\.[^\.]*$/, '') + '.png';
   path = path.replace(/\/index\.png$/, '.png');
   return path;
 };


### PR DESCRIPTION
Resolves #11 by implementing the change described at https://github.com/delucis/astro-og-canvas/issues/11#issuecomment-1472828325.