### PR TITLE
chore(dependencies): updated deterministic-object-hash from 1.3.1 to 2.0.2

### DIFF
--- a/.changeset/brown-shrimps-tell.md
+++ b/.changeset/brown-shrimps-tell.md
@@ -1,0 +1,5 @@
+---
+"astro-og-canvas": patch
+---
+
+Update `deterministic-object-hash` from 1.3.1 to 2.0.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -2507,6 +2507,11 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/base-64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg=="
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -3245,9 +3250,15 @@
       }
     },
     "node_modules/deterministic-object-hash": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/deterministic-object-hash/-/deterministic-object-hash-1.3.1.tgz",
-      "integrity": "sha512-kQDIieBUreEgY+akq0N7o4FzZCr27dPG1xr3wq267vPwDlSXQ3UMcBXHqTGUBaM/5WDS1jwTYjxRhUzHeuiAvw=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/deterministic-object-hash/-/deterministic-object-hash-2.0.2.tgz",
+      "integrity": "sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==",
+      "dependencies": {
+        "base-64": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/devalue": {
       "version": "4.3.2",
@@ -9021,7 +9032,7 @@
       "license": "MIT",
       "dependencies": {
         "canvaskit-wasm": "^0.37.0",
-        "deterministic-object-hash": "^1.3.1",
+        "deterministic-object-hash": "^2.0.2",
         "entities": "^4.4.0"
       },
       "devDependencies": {
@@ -10727,7 +10738,7 @@
         "@types/node": "^16.11.62",
         "astro": "^3.0.3",
         "canvaskit-wasm": "^0.37.0",
-        "deterministic-object-hash": "^1.3.1",
+        "deterministic-object-hash": "^2.0.2",
         "entities": "^4.4.0",
         "typescript": "^5.0.0"
       },
@@ -10757,6 +10768,11 @@
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
       "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
       "dev": true
+    },
+    "base-64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg=="
     },
     "base64-js": {
       "version": "1.5.1",
@@ -11270,9 +11286,12 @@
       "dev": true
     },
     "deterministic-object-hash": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/deterministic-object-hash/-/deterministic-object-hash-1.3.1.tgz",
-      "integrity": "sha512-kQDIieBUreEgY+akq0N7o4FzZCr27dPG1xr3wq267vPwDlSXQ3UMcBXHqTGUBaM/5WDS1jwTYjxRhUzHeuiAvw=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/deterministic-object-hash/-/deterministic-object-hash-2.0.2.tgz",
+      "integrity": "sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==",
+      "requires": {
+        "base-64": "^1.0.0"
+      }
     },
     "devalue": {
       "version": "4.3.2",

--- a/packages/astro-og-canvas/package.json
+++ b/packages/astro-og-canvas/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "canvaskit-wasm": "^0.37.0",
-    "deterministic-object-hash": "^1.3.1",
+    "deterministic-object-hash": "^2.0.2",
     "entities": "^4.4.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
This should fix deterministic-object-hash errors related with #35 