### PR TITLE
docs: add missing comma in readme

### DIFF
--- a/.changeset/honest-wolves-listen.md
+++ b/.changeset/honest-wolves-listen.md
@@ -1,0 +1,5 @@
+---
+"astro-og-canvas": patch
+---
+
+Adds missing comma in README

--- a/packages/astro-og-canvas/README.md
+++ b/packages/astro-og-canvas/README.md
@@ -47,7 +47,7 @@ pnpm i canvaskit-wasm
         title: 'Example Page',
         description: 'Description of this page shown in smaller text',
       }
-     }
+     },
 
      // For each page, this callback will be used to customize the OpenGraph image.
      getImageOptions: (path, page) => ({


### PR DESCRIPTION
While trying to blindly copy/paste the README instructions, I noticed a missing comma in one of the example.

This PR adds it.