### PR TITLE
Fix support for JPEG & WebP

### DIFF
--- a/.changeset/old-chicken-sniff.md
+++ b/.changeset/old-chicken-sniff.md
@@ -1,0 +1,5 @@
+---
+'astro-og-canvas': minor
+---
+
+Switches to using the “full” `canvaskit-wasm` build to generate images. This fixes support for rendering as JPEG or WEBP instead of the default PNG.

--- a/.changeset/three-pigs-compare.md
+++ b/.changeset/three-pigs-compare.md
@@ -1,0 +1,11 @@
+---
+'astro-og-canvas': minor
+---
+
+Updates `canvaskit-wasm` to the latest release
+
+**Note:** pnpm users may need to manually update in their project too:
+
+```sh
+pnpm i canvaskit-wasm@^0.39.1
+```

--- a/demo/src/pages/formats/[path].ts
+++ b/demo/src/pages/formats/[path].ts
@@ -1,0 +1,31 @@
+import { OGImageRoute } from 'astro-og-canvas';
+
+export const { getStaticPaths, GET } = OGImageRoute({
+  param: 'path',
+  pages: {
+    'png.md': {
+      title: 'Test image (PNG)',
+      description: 'Renders an Open Graph image to a PNG file',
+      format: 'PNG',
+    },
+    'jpeg.md': {
+      title: 'Test image (JPEG)',
+      description: 'Renders an Open Graph image to a JPEG file',
+      format: 'JPEG',
+    },
+    'webp.md': {
+      title: 'Test image (WEBP)',
+      description: 'Renders an Open Graph image to a WEBP file',
+      format: 'WEBP',
+    },
+  },
+  getSlug(path, { format }) {
+    const ext = format.toLowerCase();
+    path = path.replace(/^\/src\/pages\//, '');
+    path = path.replace(/\.[^.]*$/, '') + '.' + ext;
+    return path;
+  },
+  getImageOptions: (_path, page) => ({
+    ...page,
+  }),
+});

--- a/demo/src/pages/formats/index.md
+++ b/demo/src/pages/formats/index.md
@@ -1,0 +1,17 @@
+---
+title: Different formats
+description: Test page demonstrating that images render correctly in different formats
+layout: ../../layouts/Layout.astro
+---
+
+# Astro OpenGraph Images with CanvasKit
+
+This test renders the same image to different formats.
+
+![Example PNG](/formats/png.png)
+
+![Example JPEG](/formats/jpeg.jpeg)
+
+![Example WEBP](/formats/webp.webp)
+
+- [Home](/)

--- a/demo/src/pages/index.md
+++ b/demo/src/pages/index.md
@@ -14,3 +14,4 @@ This test project uses `astro-og-canvas` to generate OpenGraph images from code.
 - [Font Tests](/font-test)
 - [Local font test](/local-font-test)
 - [Background image tests](/background-test)
+- [Different formats](/formats)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1009,6 +1009,11 @@
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
       "dev": true
     },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.21.tgz",
+      "integrity": "sha512-pUrWq3V5PiSGFLeLxoGqReTZmiiXwY3jRkIG5sLLKjyqNxrwm/04b4nw7LSmGWJcKk59XOM/YRTUwOzo4MMlow=="
+    },
     "node_modules/acorn": {
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
@@ -2701,9 +2706,12 @@
       ]
     },
     "node_modules/canvaskit-wasm": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/canvaskit-wasm/-/canvaskit-wasm-0.37.0.tgz",
-      "integrity": "sha512-hegK3gdVQJwgOre02kFHJDEo9b+VHY/bA/N+12C7fECSosGL9Q7gwcz4vnDdOnzSoeLCRH26oTNK3gEO+dm+dg=="
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/canvaskit-wasm/-/canvaskit-wasm-0.39.1.tgz",
+      "integrity": "sha512-Gy3lCmhUdKq+8bvDrs9t8+qf7RvcjuQn+we7vTVVyqgOVO1UVfHpsnBxkTZw+R4ApEJ3D5fKySl9TU11hmjl/A==",
+      "dependencies": {
+        "@webgpu/types": "0.1.21"
+      }
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -9031,7 +9039,7 @@
       "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
-        "canvaskit-wasm": "^0.37.0",
+        "canvaskit-wasm": "^0.39.1",
         "deterministic-object-hash": "^2.0.2",
         "entities": "^4.4.0"
       },
@@ -9880,6 +9888,11 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
       "dev": true
+    },
+    "@webgpu/types": {
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.21.tgz",
+      "integrity": "sha512-pUrWq3V5PiSGFLeLxoGqReTZmiiXwY3jRkIG5sLLKjyqNxrwm/04b4nw7LSmGWJcKk59XOM/YRTUwOzo4MMlow=="
     },
     "acorn": {
       "version": "8.10.0",
@@ -10737,7 +10750,7 @@
       "requires": {
         "@types/node": "^16.11.62",
         "astro": "^3.0.3",
-        "canvaskit-wasm": "^0.37.0",
+        "canvaskit-wasm": "^0.39.1",
         "deterministic-object-hash": "^2.0.2",
         "entities": "^4.4.0",
         "typescript": "^5.0.0"
@@ -10882,9 +10895,12 @@
       "dev": true
     },
     "canvaskit-wasm": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/canvaskit-wasm/-/canvaskit-wasm-0.37.0.tgz",
-      "integrity": "sha512-hegK3gdVQJwgOre02kFHJDEo9b+VHY/bA/N+12C7fECSosGL9Q7gwcz4vnDdOnzSoeLCRH26oTNK3gEO+dm+dg=="
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/canvaskit-wasm/-/canvaskit-wasm-0.39.1.tgz",
+      "integrity": "sha512-Gy3lCmhUdKq+8bvDrs9t8+qf7RvcjuQn+we7vTVVyqgOVO1UVfHpsnBxkTZw+R4ApEJ3D5fKySl9TU11hmjl/A==",
+      "requires": {
+        "@webgpu/types": "0.1.21"
+      }
     },
     "ccount": {
       "version": "2.0.1",

--- a/packages/astro-og-canvas/package.json
+++ b/packages/astro-og-canvas/package.json
@@ -35,7 +35,7 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
-    "canvaskit-wasm": "^0.37.0",
+    "canvaskit-wasm": "^0.39.1",
     "deterministic-object-hash": "^2.0.2",
     "entities": "^4.4.0"
   },

--- a/packages/astro-og-canvas/src/assetLoaders.ts
+++ b/packages/astro-og-canvas/src/assetLoaders.ts
@@ -1,5 +1,4 @@
-import type { FontMgr } from 'canvaskit-wasm';
-import init from 'canvaskit-wasm';
+import init, { type FontMgr } from 'canvaskit-wasm/full';
 import fs from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import { shorthash } from './shorthash';
@@ -11,7 +10,7 @@ const error = (...args: any[]) => console.error('[astro-og-canvas]', ...args);
 /** CanvasKit singleton. */
 export const CanvasKitPromise = init({
   // TODO: Figure how to reliably resolve this without depending on Node.
-  locateFile: (file) => resolve(`canvaskit-wasm/bin/${file}`),
+  locateFile: (file) => resolve(`canvaskit-wasm/bin/full/${file}`),
 });
 
 class FontManager {

--- a/packages/astro-og-canvas/src/types.ts
+++ b/packages/astro-og-canvas/src/types.ts
@@ -1,4 +1,4 @@
-import type { CanvasKit } from 'canvaskit-wasm';
+import type { CanvasKit } from 'canvaskit-wasm/full';
 
 export type RGBColor = [r: number, g: number, b: number];
 export type XYWH = [x: number, y: number, w: number, h: number];

--- a/test/astro-auto-import.ts
+++ b/test/astro-auto-import.ts
@@ -21,4 +21,9 @@ test('it should have built the index page correctly', () => {
   assert.match(page, /<img src="\/og\/index.png" alt="Example image">/);
 });
 
+test('it should have rendered a JPEG correctly', () => {
+  const buff = loadImage('/formats/jpeg.jpeg');
+  assert.not.equal(buff.length, 0);
+})
+
 test.run();


### PR DESCRIPTION
- Updates `canvaskit-wasm` to latest
- Switches to the [“full” build](https://www.npmjs.com/package/canvaskit-wasm#different-canvaskit-bundles) which includes JPEG and WebP support