### PR TITLE
Fix invalid images generation for some slugs with leading slash

### DIFF
--- a/.changeset/lucky-seahorses-relax.md
+++ b/.changeset/lucky-seahorses-relax.md
@@ -1,0 +1,5 @@
+---
+'astro-og-canvas': patch
+---
+
+Fix invalid images generation for some slugs with leading slash

--- a/.changeset/lucky-seahorses-relax.md
+++ b/.changeset/lucky-seahorses-relax.md
@@ -2,4 +2,4 @@
 'astro-og-canvas': patch
 ---
 
-Fix invalid images generation for some slugs with leading slash
+Fixes image generation for slugs with a leading slash in Astro ≥4.10.2

--- a/packages/astro-og-canvas/src/routing.ts
+++ b/packages/astro-og-canvas/src/routing.ts
@@ -26,7 +26,7 @@ function createOGImageEndpoint({ getSlug = pathToSlug, ...opts }: OGImageRouteCo
     const pageEntry = Object.entries(opts.pages).find(
       (page) => {
         const slug = getSlug(...page);
-        return slug === params[opts.param] || slug.replace(/^\//, "") === params[opts.param]
+        return slug === params[opts.param] || slug.replace(/^\//, "") === params[opts.param];
       }
     );
     if (!pageEntry) return new Response('Page not found', { status: 404 });

--- a/packages/astro-og-canvas/src/routing.ts
+++ b/packages/astro-og-canvas/src/routing.ts
@@ -25,7 +25,8 @@ function createOGImageEndpoint({ getSlug = pathToSlug, ...opts }: OGImageRouteCo
   return async function getOGImage({ params }) {
     const pageEntry = Object.entries(opts.pages).find(
       (page) => {
-        return getSlug(...page) === params[opts.param] || getSlug(...page).replace(/^\//g, "") === params[opts.param]
+        const slug = getSlug(...page);
+        return slug === params[opts.param] || slug.replace(/^\//, "") === params[opts.param]
       }
     );
     if (!pageEntry) return new Response('Page not found', { status: 404 });

--- a/packages/astro-og-canvas/src/routing.ts
+++ b/packages/astro-og-canvas/src/routing.ts
@@ -24,7 +24,9 @@ function makeGetStaticPaths({
 function createOGImageEndpoint({ getSlug = pathToSlug, ...opts }: OGImageRouteConfig): APIRoute {
   return async function getOGImage({ params }) {
     const pageEntry = Object.entries(opts.pages).find(
-      (page) => getSlug(...page) === params[opts.param]
+      (page) => {
+        return getSlug(...page) === params[opts.param] || getSlug(...page).replace(/^\//g, "") === params[opts.param]
+      }
     );
     if (!pageEntry) return new Response('Page not found', { status: 404 });
 


### PR DESCRIPTION
### Description

Closes #61

Thanks a lot @delucis for helping me investigate the issue in https://github.com/delucis/astro-og-canvas/issues/61. It was a really interesting use case. It was a really interesting use case. I'm still not entirely sure if it could be a bug in Astro, but let's strengthen `astro-og-canvas` by modifying the comparison method in `getOGImage` to compare slugs both with and without leading paths.

I quickly experimented with different approaches within `astro-og-canvas` but the suggestion in https://github.com/delucis/astro-og-canvas/issues/61#issuecomment-2211116517 seems to be the most robust solution.

Since the patch is a simple one-line fix, feel free to close the PR if there's a better alternative.

The complexity of the problem stretched my creativity for the commit message and changeset wording
Feel free to adjust them as needed.

I haven't added any specific tests, but it probably can be possible if needed.

#### How to test with the original issue

One approach is to:
1. Get the Astro minimal example at https://github.com/withastro/astro/tree/main/examples/minimal that can be built by executing `pnpm --filter @example/minimal run build`
2. Create the files described in https://github.com/delucis/astro-og-canvas/issues/61#issuecomment-2203490945.
3. Compile `astro-og-canvas` with the patch
4. `npm run build ; rm /Users/xxx/as
tro/astro/examples/minimal/node_modules/astro-og-canvas/dist/* ; cp dist/* /Users/xxx/astro/astro/examples
/minimal/node_modules/astro-og-canvas/dist/` (there's probably a way to do it with `pnpm link` or `npm link` but I was too lazy this morning 😇)
5. Compile the Astro minimal example
6. Observe the generated images

_Note: I've also done the same thing for my repo at https://github.com/Open-reSource/openresource.dev and the images are well generated_