### PR TITLE
Refactor CanvasKit initialization to log more helpful error for PNPM users

### DIFF
--- a/.changeset/chilly-students-tell.md
+++ b/.changeset/chilly-students-tell.md
@@ -1,0 +1,5 @@
+---
+"astro-og-canvas": patch
+---
+
+Refactors CanvasKit initialization to log more helpful error in PNPM projects without `canvaskit-wasm` installed

--- a/packages/astro-og-canvas/src/generateOpenGraphImage.ts
+++ b/packages/astro-og-canvas/src/generateOpenGraphImage.ts
@@ -2,7 +2,7 @@ import { deterministicString } from 'deterministic-object-hash';
 import { decodeHTMLStrict } from 'entities';
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { CanvasKitPromise, fontManager, loadImage } from './assetLoaders';
+import { getCanvasKit, fontManager, loadImage } from './assetLoaders';
 import { shorthash } from './shorthash';
 import type {
   FontConfig,
@@ -132,7 +132,7 @@ export async function generateOpenGraphImage({
   };
   margin[border.side] += border.width;
 
-  const CanvasKit = await CanvasKitPromise;
+  const CanvasKit = await getCanvasKit();
 
   const textStyle = (fontConfig: Required<FontConfig>) => ({
     color: CanvasKit.Color(...fontConfig.color),


### PR DESCRIPTION
Inspired by @HiDeoo’s [suggestion in a Starlight issue](https://github.com/withastro/starlight/issues/2106#issuecomment-2212505421), this PR refactors our loading of CanvasKit to augment the somewhat cryptic `__dirname is not defined` error when `canvaskit-wasm` is not a direct dependency in projects using PNPM (due to PNPM’s hoisting rules).

This error now includes a hint to install the extra package:

```
__dirname is not defined

This error is often thrown when using PNPM without installing `canvaskit-wasm` directly.
Install this required dependency by running `pnpm add canvaskit-wasm`
```