### PR TITLE
Allow Astro v5 as a peer dependency

### DIFF
--- a/.changeset/kind-emus-judge.md
+++ b/.changeset/kind-emus-judge.md
@@ -1,0 +1,5 @@
+---
+"astro-og-canvas": patch
+---
+
+Expands peer dependencies to support Astro v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        astro: [^3, ^4]
+        astro: [^3, ^4, ^5]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/packages/astro-og-canvas/package.json
+++ b/packages/astro-og-canvas/package.json
@@ -40,7 +40,7 @@
     "entities": "^4.4.0"
   },
   "peerDependencies": {
-    "astro": "^3.0.0 || ^4.0.0"
+    "astro": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "engines": {
     "node": ">=18.14.1"


### PR DESCRIPTION
The package seems to work fine with the new version.