### PR TITLE
Improve handling of parallel requests to generate OG images

### DIFF
--- a/.changeset/pretty-keys-explode.md
+++ b/.changeset/pretty-keys-explode.md
@@ -1,0 +1,5 @@
+---
+'astro-og-canvas': patch
+---
+
+Improves handling of cases where OG images are requested to be generated in parallel

--- a/packages/astro-og-canvas/src/assetLoaders.ts
+++ b/packages/astro-og-canvas/src/assetLoaders.ts
@@ -1,7 +1,8 @@
-import type { FontMgr, CanvasKit } from 'canvaskit-wasm/full';
+import type { CanvasKit, FontMgr } from 'canvaskit-wasm/full';
+import { Buffer } from 'node:buffer';
 import fs from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { Buffer } from 'node:buffer';
+import pQueue from './queue';
 import { shorthash } from './shorthash';
 const { resolve } = createRequire(import.meta.url);
 
@@ -40,7 +41,7 @@ class FontManager {
   readonly #cache = new Map<string, ArrayBuffer | undefined>();
   readonly #hashCache = new Map<string, string>();
   /** Promise to co-ordinate `#get` calls to run sequentially. */
-  #loading = Promise.resolve();
+  #queue = pQueue();
   /** Current `CanvasKit.FontMgr` instance. */
   #manager?: FontMgr;
 
@@ -71,32 +72,27 @@ class FontManager {
    * @returns A font manager for all fonts loaded up until now.
    */
   async get(fontUrls: string[]): Promise<FontMgr> {
-    this.#loading = this.#loading.then(
-      () =>
-        new Promise<void>(async (resolve) => {
-          let hasNew = false;
-          for (const url of fontUrls) {
-            if (this.#cache.has(url)) continue;
-            hasNew = true;
-            debug('Loading', url);
-            if (/^https?:\/\//.test(url)) {
-              const response = await fetch(url);
-              if (response.ok) {
-                this.#cache.set(url, await response.arrayBuffer());
-              } else {
-                this.#cache.set(url, undefined);
-                error(response.status, response.statusText, '—', url);
-              }
-            } else {
-              const file = await fs.readFile(url);
-              this.#cache.set(url, file);
-            }
+    await this.#queue(async () => {
+      let hasNew = false;
+      for (const url of fontUrls) {
+        if (this.#cache.has(url)) continue;
+        hasNew = true;
+        debug('Loading', url);
+        if (/^https?:\/\//.test(url)) {
+          const response = await fetch(url);
+          if (response.ok) {
+            this.#cache.set(url, await response.arrayBuffer());
+          } else {
+            this.#cache.set(url, undefined);
+            error(response.status, response.statusText, '—', url);
           }
-          if (hasNew) await this.#updateManager();
-          resolve();
-        })
-    );
-    await this.#loading;
+        } else {
+          const file = await fs.readFile(url);
+          this.#cache.set(url, file);
+        }
+      }
+      if (hasNew) await this.#updateManager();
+    });
     return this.#manager!;
   }
 

--- a/packages/astro-og-canvas/src/assetLoaders.ts
+++ b/packages/astro-og-canvas/src/assetLoaders.ts
@@ -71,28 +71,30 @@ class FontManager {
    * @returns A font manager for all fonts loaded up until now.
    */
   async get(fontUrls: string[]): Promise<FontMgr> {
-    await this.#loading;
     let hasNew = false;
-    this.#loading = new Promise<void>(async (resolve) => {
-      for (const url of fontUrls) {
-        if (this.#cache.has(url)) continue;
-        hasNew = true;
-        debug('Loading', url);
-        if (/^https?:\/\//.test(url)) {
-          const response = await fetch(url);
-          if (response.ok) {
-            this.#cache.set(url, await response.arrayBuffer());
-          } else {
-            this.#cache.set(url, undefined);
-            error(response.status, response.statusText, '—', url);
+    this.#loading = this.#loading.then(
+      () =>
+        new Promise<void>(async (resolve) => {
+          for (const url of fontUrls) {
+            if (this.#cache.has(url)) continue;
+            hasNew = true;
+            debug('Loading', url);
+            if (/^https?:\/\//.test(url)) {
+              const response = await fetch(url);
+              if (response.ok) {
+                this.#cache.set(url, await response.arrayBuffer());
+              } else {
+                this.#cache.set(url, undefined);
+                error(response.status, response.statusText, '—', url);
+              }
+            } else {
+              const file = await fs.readFile(url);
+              this.#cache.set(url, file);
+            }
           }
-        } else {
-          const file = await fs.readFile(url);
-          this.#cache.set(url, file);
-        }
-      }
-      resolve();
-    });
+          resolve();
+        })
+    );
     await this.#loading;
     if (hasNew) await this.#updateManager();
     return this.#manager!;

--- a/packages/astro-og-canvas/src/assetLoaders.ts
+++ b/packages/astro-og-canvas/src/assetLoaders.ts
@@ -45,8 +45,12 @@ class FontManager {
   /** Current `CanvasKit.FontMgr` instance. */
   #manager?: FontMgr;
 
-  /** Instantiate a new `CanvasKit.FontMgr` instance with all the currently cached fonts. */
-  async #updateManager(): Promise<void> {
+  /** Get a `CanvasKit.FontMgr` instance with all the currently cached fonts, creating a new one if needed. */
+  async #getOrCreateManager(shouldUpdate: boolean): Promise<FontMgr> {
+    if (!shouldUpdate && this.#manager) {
+      return this.#manager;
+    }
+
     const CanvasKit = await getCanvasKit();
     const fontData = Array.from(this.#cache.values()).filter((v) => !!v) as ArrayBuffer[];
     this.#manager = CanvasKit.FontMgr.FromData(...fontData)!;
@@ -57,6 +61,8 @@ class FontManager {
     const fontFamilies = [];
     for (let i = 0; i < fontCount; i++) fontFamilies.push(this.#manager.getFamilyName(i));
     debug('Loaded', fontCount, 'font families:\n' + fontFamilies.join(', '));
+
+    return this.#manager;
   }
 
   /**
@@ -72,7 +78,7 @@ class FontManager {
    * @returns A font manager for all fonts loaded up until now.
    */
   async get(fontUrls: string[]): Promise<FontMgr> {
-    await this.#queue(async () => {
+    return this.#queue(async () => {
       let hasNew = false;
       for (const url of fontUrls) {
         if (this.#cache.has(url)) continue;
@@ -91,9 +97,8 @@ class FontManager {
           this.#cache.set(url, file);
         }
       }
-      if (hasNew) await this.#updateManager();
+      return this.#getOrCreateManager(hasNew);
     });
-    return this.#manager!;
   }
 
   /** Get a short hash for a given font resource. */
@@ -122,8 +127,8 @@ const images = { cache: new Map<string, LoadedImage>(), queue: pQueue() };
  * @param path Path to an image file, e.g. `./src/logo.png`.
  * @returns Buffer containing the image contents.
  */
-export const loadImage = async (path: string): Promise<LoadedImage> => {
-  return await images.queue(async () => {
+export const loadImage = async (path: string): Promise<LoadedImage> =>
+  images.queue(async () => {
     const cached = images.cache.get(path);
     if (cached) {
       return cached;
@@ -135,4 +140,3 @@ export const loadImage = async (path: string): Promise<LoadedImage> => {
       return image;
     }
   });
-};

--- a/packages/astro-og-canvas/src/assetLoaders.ts
+++ b/packages/astro-og-canvas/src/assetLoaders.ts
@@ -115,7 +115,7 @@ interface LoadedImage {
   hash: string;
 }
 
-const images = { cache: new Map<string, LoadedImage>(), loading: Promise.resolve() };
+const images = { cache: new Map<string, LoadedImage>(), queue: pQueue() };
 
 /**
  * Load an image. Backed by an in-memory cache to avoid repeat disk-reads.
@@ -123,20 +123,16 @@ const images = { cache: new Map<string, LoadedImage>(), loading: Promise.resolve
  * @returns Buffer containing the image contents.
  */
 export const loadImage = async (path: string): Promise<LoadedImage> => {
-  await images.loading;
-  let image: LoadedImage;
-  images.loading = new Promise(async (resolve) => {
+  return await images.queue(async () => {
     const cached = images.cache.get(path);
     if (cached) {
-      image = cached;
+      return cached;
     } else {
       // TODO: Figure out if there’s deno-compatible way to load images.
       const buffer = await fs.readFile(path);
-      image = { buffer, hash: shorthash(buffer.toString()) };
+      const image = { buffer, hash: shorthash(buffer.toString()) };
       images.cache.set(path, image);
+      return image;
     }
-    resolve();
   });
-  await images.loading;
-  return image!;
 };

--- a/packages/astro-og-canvas/src/assetLoaders.ts
+++ b/packages/astro-og-canvas/src/assetLoaders.ts
@@ -2,7 +2,7 @@ import type { CanvasKit, FontMgr } from 'canvaskit-wasm/full';
 import { Buffer } from 'node:buffer';
 import fs from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import pQueue from './queue';
+import { pQueue } from './queue';
 import { shorthash } from './shorthash';
 const { resolve } = createRequire(import.meta.url);
 
@@ -40,7 +40,7 @@ class FontManager {
   /** Font data cache to avoid repeat downloads. */
   readonly #cache = new Map<string, ArrayBuffer | undefined>();
   readonly #hashCache = new Map<string, string>();
-  /** Promise to co-ordinate `#get` calls to run sequentially. */
+  /** Queue to co-ordinate `#get` calls to run sequentially. */
   #queue = pQueue();
   /** Current `CanvasKit.FontMgr` instance. */
   #manager?: FontMgr;

--- a/packages/astro-og-canvas/src/assetLoaders.ts
+++ b/packages/astro-og-canvas/src/assetLoaders.ts
@@ -71,10 +71,10 @@ class FontManager {
    * @returns A font manager for all fonts loaded up until now.
    */
   async get(fontUrls: string[]): Promise<FontMgr> {
-    let hasNew = false;
     this.#loading = this.#loading.then(
       () =>
         new Promise<void>(async (resolve) => {
+          let hasNew = false;
           for (const url of fontUrls) {
             if (this.#cache.has(url)) continue;
             hasNew = true;
@@ -92,11 +92,11 @@ class FontManager {
               this.#cache.set(url, file);
             }
           }
+          if (hasNew) await this.#updateManager();
           resolve();
         })
     );
     await this.#loading;
-    if (hasNew) await this.#updateManager();
     return this.#manager!;
   }
 

--- a/packages/astro-og-canvas/src/queue.ts
+++ b/packages/astro-og-canvas/src/queue.ts
@@ -1,3 +1,6 @@
+// Derived from https://github.com/sindresorhus/p-limit under MIT License
+// p-limit is copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+
 type ResolveCallback<T extends unknown> = (val: T | PromiseLike<T>) => void;
 
 /**

--- a/packages/astro-og-canvas/src/queue.ts
+++ b/packages/astro-og-canvas/src/queue.ts
@@ -18,17 +18,12 @@ export function pQueue() {
   const queue: Array<(val?: unknown) => void> = [];
   let activeCount = 0;
 
+  /** Process the next queued function if we're under the concurrency limit. */
   const resumeNext = () => {
-    // Process the next queued function if we're under the concurrency limit
     if (activeCount < 1 && queue.length > 0) {
       activeCount++;
       queue.shift()!();
     }
-  };
-
-  const next = () => {
-    activeCount--;
-    resumeNext();
   };
 
   const run = async <T extends unknown>(task: () => T, resolve: ResolveCallback<T>) => {
@@ -46,7 +41,8 @@ export function pQueue() {
     } catch {}
 
     // Decrement active count and process next queued function
-    next();
+    activeCount--;
+    resumeNext();
   };
 
   const enqueue = <T extends unknown>(task: () => T, resolve: ResolveCallback<T>) => {
@@ -60,6 +56,7 @@ export function pQueue() {
     if (activeCount < 1) resumeNext();
   };
 
+  /** Run `task` when any previously enqueued tasks have completed. */
   const generator = <T extends unknown>(task: () => T) =>
     new Promise<T>((resolve) => {
       enqueue(task, resolve);

--- a/packages/astro-og-canvas/src/queue.ts
+++ b/packages/astro-og-canvas/src/queue.ts
@@ -1,0 +1,69 @@
+type ResolveCallback<T extends unknown> = (val: T | PromiseLike<T>) => void;
+
+/**
+ * This is a queuing/limiting system based on the `p-limit` npm package, but heavily simplified
+ * to a minimal API surface. All it does is ensure tasks run one at a time, sequentially.
+ *
+ * @example
+ * const queue = pQueue();
+ * const input = [
+ * 	limit(() => fetchSomething('foo')),
+ * 	limit(() => fetchSomething('bar')),
+ * 	limit(() => doSomething())
+ * ];
+ * // Each promise is run sequentially rather than in parallel.
+ * await Promise.all(input);
+ */
+export default function pQueue() {
+  const queue: Array<(val?: unknown) => void> = [];
+  let activeCount = 0;
+
+  const resumeNext = () => {
+    // Process the next queued function if we're under the concurrency limit
+    if (activeCount < 1 && queue.length > 0) {
+      activeCount++;
+      queue.shift()!();
+    }
+  };
+
+  const next = () => {
+    activeCount--;
+    resumeNext();
+  };
+
+  const run = async <T extends unknown>(task: () => T, resolve: ResolveCallback<T>) => {
+    // Execute the function and capture the result promise
+    const result = (async () => task())();
+
+    // Resolve immediately with the promise (don't wait for completion)
+    resolve(result);
+
+    // Wait for the function to complete (success or failure)
+    // We catch errors here to prevent unhandled rejections,
+    // but the original promise rejection is preserved for the caller
+    try {
+      await result;
+    } catch {}
+
+    // Decrement active count and process next queued function
+    next();
+  };
+
+  const enqueue = <T extends unknown>(task: () => T, resolve: ResolveCallback<T>) => {
+    // Queue the internal resolve function instead of the run function
+    // to preserve the asynchronous execution context.
+    new Promise((internalResolve) => {
+      queue.push(internalResolve);
+    }).then(() => run(task, resolve));
+
+    // Start processing immediately if we haven't reached the concurrency limit
+    if (activeCount < 1) resumeNext();
+  };
+
+  const generator = <T extends unknown>(task: () => T) =>
+    new Promise<T>((resolve) => {
+      enqueue(task, resolve);
+    });
+
+  return generator;
+}

--- a/packages/astro-og-canvas/src/queue.ts
+++ b/packages/astro-og-canvas/src/queue.ts
@@ -14,7 +14,7 @@ type ResolveCallback<T extends unknown> = (val: T | PromiseLike<T>) => void;
  * // Each promise is run sequentially rather than in parallel.
  * await Promise.all(input);
  */
-export default function pQueue() {
+export function pQueue() {
   const queue: Array<(val?: unknown) => void> = [];
   let activeCount = 0;
 


### PR DESCRIPTION
This PR updates the font and image loaders to properly handle cases where multiple instantiations of the OG image generator occur simultaneously. In regular usage this should not really happen, but this PR at least ensures that the font manager and image loader queue requests properly so they happen sequentially rather than accumulating all at once.

Closes #92 