### PR TITLE
Properly configure changesets to use the GitHub changelog generator

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@2.0.0/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": ["@changesets/changelog-github", { "repo": "delucis/astro-og-canvas" }],
   "commit": false,
   "fixed": [],
   "linked": [],


### PR DESCRIPTION
Realised that although `@changesets/changelog-github` is installed, I never actually configured changesets to use it. This PR fixes that to improve the changelog entries generated for future releases.