### PR TITLE
Drop support for older versions of Astro

### DIFF
--- a/.changeset/funny-cloths-grab.md
+++ b/.changeset/funny-cloths-grab.md
@@ -1,0 +1,5 @@
+---
+'astro-og-canvas': minor
+---
+
+Drops official support for Astro 3 and 4. Use Astro 5 instead.

--- a/.changeset/new-teams-read.md
+++ b/.changeset/new-teams-read.md
@@ -1,0 +1,5 @@
+---
+'astro-og-canvas': patch
+---
+
+Adds experimental support for Astro 6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        astro: [^3, ^4, ^5]
+        astro: [^5, alpha]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: 18.20.8
+          node-version: 24.12.0
 
       - run: pnpm i
 

--- a/packages/astro-og-canvas/package.json
+++ b/packages/astro-og-canvas/package.json
@@ -40,9 +40,6 @@
     "entities": "^7.0.0"
   },
   "peerDependencies": {
-    "astro": "^3.0.0 || ^4.0.0 || ^5.0.0"
-  },
-  "engines": {
-    "node": ">=18.14.1"
+    "astro": "^5.0.0 || ^6.0.0-alpha"
   }
 }


### PR DESCRIPTION
This PR drops official support for versions of Astro predating v5. No code has actually changed but most Astro users are now on v5 so this frees us up to focus on v5 and the upcoming v6.