### PR TITLE
Improve `OGImageRoute` typing

### DIFF
--- a/.changeset/huge-months-lose.md
+++ b/.changeset/huge-months-lose.md
@@ -1,0 +1,20 @@
+---
+'astro-og-canvas': minor
+---
+
+Adds type safety to `OGImageRoute`. The `page` parameter in `getSlug()` and `getImageOptions()` is now correctly inferred from the value passed to `pages` instead of being typed as `any`.
+
+```js
+OGImageRoute({
+  pages: {
+   'example': {
+     title: 'Example Page',
+     description: 'Description of this page shown in smaller text',
+   }
+  },
+  getImageOptions: (path, page) => {
+    page
+    // ^ { title: string; description: string } 
+  }
+})
+```

--- a/.changeset/huge-months-lose.md
+++ b/.changeset/huge-months-lose.md
@@ -14,7 +14,7 @@ OGImageRoute({
   },
   getImageOptions: (path, page) => {
     page
-    // ^ { title: string; description: string } 
+    // ^? { title: string; description: string } 
   }
 })
 ```

--- a/.changeset/huge-months-lose.md
+++ b/.changeset/huge-months-lose.md
@@ -18,3 +18,5 @@ OGImageRoute({
   }
 })
 ```
+
+⚠️ **Potentially breaking change:** If you are type checking your code base, you may see type errors if you are accessing `page` in `getSlug()` or `getImageOptions()` in a non-type-safe way and will need to either update that code or add some additional types.

--- a/.changeset/smooth-masks-flow.md
+++ b/.changeset/smooth-masks-flow.md
@@ -1,0 +1,5 @@
+---
+'astro-og-canvas': minor
+---
+
+Exports `OGImageOptions` type

--- a/demo/src/pages/background-test/[path].ts
+++ b/demo/src/pages/background-test/[path].ts
@@ -1,4 +1,4 @@
-import { OGImageRoute } from 'astro-og-canvas';
+import { OGImageRoute, type OGImageOptions } from 'astro-og-canvas';
 
 const logoPath = './src/astro-docs-logo.png';
 const bgPath = './src/bgPattern.png';
@@ -62,7 +62,7 @@ export const { getStaticPaths, GET } = OGImageRoute({
       title: 'bgImage: {\n  position: ["end", "center"],\n}',
       font: { title: { color: [0, 0, 0], weight: 'Bold' } },
     },
-  },
+  } satisfies Record<string, Partial<OGImageOptions>>,
   getImageOptions: (_path, page) => ({
     title: '',
     description: '',

--- a/demo/src/pages/formats/[path].ts
+++ b/demo/src/pages/formats/[path].ts
@@ -1,4 +1,4 @@
-import { OGImageRoute } from 'astro-og-canvas';
+import { OGImageRoute, type OGImageOptions } from 'astro-og-canvas';
 
 export const { getStaticPaths, GET } = OGImageRoute({
   param: 'path',
@@ -18,7 +18,7 @@ export const { getStaticPaths, GET } = OGImageRoute({
       description: 'Renders an Open Graph image to a WEBP file',
       format: 'WEBP',
     },
-  },
+  } satisfies Record<string, Partial<OGImageOptions>>,
   getSlug(path, { format }) {
     const ext = format.toLowerCase();
     path = path.replace(/^\/src\/pages\//, '');

--- a/demo/src/pages/og/[...route].ts
+++ b/demo/src/pages/og/[...route].ts
@@ -1,8 +1,12 @@
+import type { MarkdownInstance } from 'astro';
 import { OGImageRoute } from 'astro-og-canvas';
 
 export const { getStaticPaths, GET } = OGImageRoute({
   param: 'route',
-  pages: import.meta.glob('/src/pages/**/*.md', { eager: true }),
+  pages: import.meta.glob<MarkdownInstance<{ title?: string; description?: string }>>(
+    '/src/pages/**/*.md',
+    { eager: true }
+  ),
   getImageOptions: (_path, page) => ({
     title: page.frontmatter.title,
     description: page.frontmatter.description,

--- a/packages/astro-og-canvas/src/index.ts
+++ b/packages/astro-og-canvas/src/index.ts
@@ -1,2 +1,3 @@
 export { generateOpenGraphImage } from './generateOpenGraphImage';
 export { OGImageRoute } from './routing';
+export type { OGImageOptions } from './types';

--- a/packages/astro-og-canvas/src/routing.ts
+++ b/packages/astro-og-canvas/src/routing.ts
@@ -13,7 +13,7 @@ function makeGetStaticPaths({
   pages,
   param,
   getSlug = pathToSlug,
-}: OGImageRouteConfig): GetStaticPaths {
+}: OGImageRouteConfig<any>): GetStaticPaths {
   const slugs = Object.entries(pages).map((page) => getSlug(...page));
   const paths = slugs.map((slug) => ({ params: { [param]: slug } }));
   return function getStaticPaths() {
@@ -21,7 +21,10 @@ function makeGetStaticPaths({
   };
 }
 
-function createOGImageEndpoint({ getSlug = pathToSlug, ...opts }: OGImageRouteConfig): APIRoute {
+function createOGImageEndpoint({
+  getSlug = pathToSlug,
+  ...opts
+}: OGImageRouteConfig<any>): APIRoute {
   return async function getOGImage({ params }) {
     const pageEntry = Object.entries(opts.pages).find(
       (page) => {
@@ -37,7 +40,7 @@ function createOGImageEndpoint({ getSlug = pathToSlug, ...opts }: OGImageRouteCo
   };
 }
 
-export function OGImageRoute(opts: OGImageRouteConfig): {
+export function OGImageRoute<T>(opts: OGImageRouteConfig<T>): {
   getStaticPaths: GetStaticPaths;
   GET: APIRoute;
 } {
@@ -47,9 +50,9 @@ export function OGImageRoute(opts: OGImageRouteConfig): {
   };
 }
 
-interface OGImageRouteConfig {
-  pages: { [path: string]: any };
+interface OGImageRouteConfig<T extends unknown> {
+  pages: { [path: string]: T };
   param: string;
-  getSlug?: (path: string, page: any) => string;
-  getImageOptions: (path: string, page: any) => OGImageOptions | Promise<OGImageOptions>;
+  getSlug?: (path: string, page: T) => string;
+  getImageOptions: (path: string, page: T) => OGImageOptions | Promise<OGImageOptions>;
 }


### PR DESCRIPTION
Closes #115

This PR adds type safety to `OGImageRoute`. The `page` parameter in `getSlug()` and `getImageOptions()` is now correctly inferred from the value passed to `pages` instead of being typed as `any`:

```js
OGImageRoute({
  pages: {
   'example': {
     title: 'Example Page',
     description: 'Description of this page shown in smaller text',
   }
  },
  getImageOptions: (path, page) => {
    page
    // ^? { title: string; description: string } 
  }
})
```
