### PR TITLE
Fix default getSlug() for non-PNG image formats

### DIFF
--- a/.changeset/clear-toys-push.md
+++ b/.changeset/clear-toys-push.md
@@ -1,0 +1,5 @@
+---
+'astro-og-canvas': patch
+---
+
+Fixes using the built-in `getSlug()` for OG images with `format: "JPEG"` or `format: "WEBP"`

--- a/.changeset/good-seals-say.md
+++ b/.changeset/good-seals-say.md
@@ -1,0 +1,14 @@
+---
+'astro-og-canvas': minor
+---
+
+Makes `OGImageRoute()` asynchronous.
+
+⚠️ **BREAKING CHANGE:** You must now `await` the result of `OGImageRoute()`:
+
+```diff
+import { OGImageRoute } from 'astro-og-canvas';
+
+- export const { getStaticPaths, GET } = OGImageRoute({
++ export const { getStaticPaths, GET } = await OGImageRoute({
+```

--- a/demo/src/pages/background-test/[path].ts
+++ b/demo/src/pages/background-test/[path].ts
@@ -3,7 +3,7 @@ import { OGImageRoute, type OGImageOptions } from 'astro-og-canvas';
 const logoPath = './src/astro-docs-logo.png';
 const bgPath = './src/bgPattern.png';
 
-export const { getStaticPaths, GET } = OGImageRoute({
+export const { getStaticPaths, GET } = await OGImageRoute({
   param: 'path',
   pages: {
     'contain.md': {

--- a/demo/src/pages/font-test/[path].ts
+++ b/demo/src/pages/font-test/[path].ts
@@ -1,7 +1,7 @@
 import { OGImageRoute } from 'astro-og-canvas';
 import { pages } from './_pages';
 
-export const { getStaticPaths, GET } = OGImageRoute({
+export const { getStaticPaths, GET } = await OGImageRoute({
   param: 'path',
   pages,
   getImageOptions: (_path, page) => ({

--- a/demo/src/pages/formats/[path].ts
+++ b/demo/src/pages/formats/[path].ts
@@ -1,6 +1,6 @@
 import { OGImageRoute, type OGImageOptions } from 'astro-og-canvas';
 
-export const { getStaticPaths, GET } = OGImageRoute({
+export const { getStaticPaths, GET } = await OGImageRoute({
   param: 'path',
   pages: {
     'png.md': {

--- a/demo/src/pages/local-font-test/[path].ts
+++ b/demo/src/pages/local-font-test/[path].ts
@@ -1,6 +1,6 @@
 import { OGImageRoute } from 'astro-og-canvas';
 
-export const { getStaticPaths, GET } = OGImageRoute({
+export const { getStaticPaths, GET } = await OGImageRoute({
   param: 'path',
   pages: {
     'local.md': {

--- a/demo/src/pages/og/[...route].ts
+++ b/demo/src/pages/og/[...route].ts
@@ -1,7 +1,7 @@
 import type { MarkdownInstance } from 'astro';
 import { OGImageRoute } from 'astro-og-canvas';
 
-export const { getStaticPaths, GET } = OGImageRoute({
+export const { getStaticPaths, GET } = await OGImageRoute({
   param: 'route',
   pages: import.meta.glob<MarkdownInstance<{ title?: string; description?: string }>>(
     '/src/pages/**/*.md',

--- a/packages/astro-og-canvas/README.md
+++ b/packages/astro-og-canvas/README.md
@@ -34,7 +34,7 @@ pnpm i canvaskit-wasm
 
    import { OGImageRoute } from 'astro-og-canvas';
 
-   export const { getStaticPaths, GET } = OGImageRoute({
+   export const { getStaticPaths, GET } = await OGImageRoute({
      // Tell us the name of your dynamic route segment.
      // In this case it’s `route`, because the file is named `[...route].ts`.
      param: 'route',
@@ -78,7 +78,7 @@ const collectionEntries = await getCollection('my-collection');
 // to { 'post.md': { title: 'Example', description: '' } }
 const pages = Object.fromEntries(collectionEntries.map(({ slug, data }) => [slug, data]));
 
-export const { getStaticPaths, GET } = OGImageRoute({
+export const { getStaticPaths, GET } = await OGImageRoute({
   // Tell us the name of your dynamic route segment.
   // In this case it’s `route`, because the file is named `[...route].ts`.
   param: 'route',
@@ -101,7 +101,7 @@ In the following example, every Markdown file in the project’s `src/pages/` di
 ```js
 import { OGImageRoute } from 'astro-og-canvas';
 
-export const { getStaticPaths, GET } = OGImageRoute({
+export const { getStaticPaths, GET } = await OGImageRoute({
   // Tell us the name of your dynamic route segment.
   // In this case it’s `route`, because the file is named `[...route].ts`.
   param: 'route',
@@ -140,7 +140,7 @@ for (const { url } of results) {
   pokemon[details.name] = details;
 }
 
-export const { getStaticPaths, GET } = OGImageRoute({
+export const { getStaticPaths, GET } = await OGImageRoute({
   pages: pokemon,
 
   getImageOptions: (path, page) => ({

--- a/packages/astro-og-canvas/src/routing.ts
+++ b/packages/astro-og-canvas/src/routing.ts
@@ -2,57 +2,56 @@ import type { APIRoute, GetStaticPaths } from 'astro';
 import { generateOpenGraphImage } from './generateOpenGraphImage';
 import type { OGImageOptions } from './types';
 
-const pathToSlug = (path: string): string => {
+const pathToSlug = (path: string, _page: any, imageOptions: OGImageOptions): string => {
+  const format = imageOptions.format || 'PNG';
+  const extension = '.' + format.toLowerCase();
   path = path.replace(/^\/src\/pages\//, '');
-  path = path.replace(/\.[^\.]*$/, '') + '.png';
-  path = path.replace(/\/index\.png$/, '.png');
+  path = path.replace(/\.[^\.]*$/, '') + extension;
+  path = path.replace(/\/index\.(png|jpeg|webp)$/, extension);
   return path;
 };
 
-function makeGetStaticPaths({
+async function makeGetStaticPaths({
   pages,
   param,
   getSlug = pathToSlug,
-}: OGImageRouteConfig<any>): GetStaticPaths {
-  const slugs = Object.entries(pages).map((page) => getSlug(...page));
-  const paths = slugs.map((slug) => ({ params: { [param]: slug } }));
+  getImageOptions,
+}: OGImageRouteConfig<any>): Promise<GetStaticPaths> {
+  const entries = await Promise.all(
+    Object.entries(pages).map(async (page) => {
+      const imageOptions = await getImageOptions(...page);
+      const slug = getSlug(...page, imageOptions);
+      return { slug, imageOptions };
+    })
+  );
+  const paths = entries.map(({ slug, imageOptions }) => ({
+    params: { [param]: slug },
+    props: { imageOptions },
+  }));
   return function getStaticPaths() {
     return paths;
   };
 }
 
-function createOGImageEndpoint({
-  getSlug = pathToSlug,
-  ...opts
-}: OGImageRouteConfig<any>): APIRoute {
-  return async function getOGImage({ params }) {
-    const pageEntry = Object.entries(opts.pages).find(
-      (page) => {
-        const slug = getSlug(...page);
-        return slug === params[opts.param] || slug.replace(/^\//, "") === params[opts.param];
-      }
-    );
-    if (!pageEntry) return new Response('Page not found', { status: 404 });
-
-    return new Response(await generateOpenGraphImage(
-      await opts.getImageOptions(...pageEntry)
-    ));
+function createOGImageEndpoint(): APIRoute {
+  return async function getOGImage({ props }) {
+    return new Response(await generateOpenGraphImage(props.imageOptions));
   };
 }
 
-export function OGImageRoute<T>(opts: OGImageRouteConfig<T>): {
+export async function OGImageRoute<T>(opts: OGImageRouteConfig<T>): Promise<{
   getStaticPaths: GetStaticPaths;
   GET: APIRoute;
-} {
+}> {
   return {
-    getStaticPaths: makeGetStaticPaths(opts),
-    GET: createOGImageEndpoint(opts),
+    getStaticPaths: await makeGetStaticPaths(opts),
+    GET: createOGImageEndpoint(),
   };
 }
 
 interface OGImageRouteConfig<T extends unknown> {
   pages: { [path: string]: T };
   param: string;
-  getSlug?: (path: string, page: T) => string;
+  getSlug?: (path: string, page: T, imageOptions: OGImageOptions) => string;
   getImageOptions: (path: string, page: T) => OGImageOptions | Promise<OGImageOptions>;
 }


### PR DESCRIPTION
Closes #66 

This PR fixes a long-standing issue when returning a `format` other than `"PNG"` from `getImageOptions()`. Previously, even if choosing `format: "JPEG"` or `format: "WEBP"`, the default `getSlug()` implementation would still generate a slug with the extension `.png`, breaking output on many servers that rely on extension for MIME type detection.

The fix involves moving the `getImageOptions()` call earlier so that `getSlug()` can read the `format` value it returns.

Because `getImageOptions()` can be async, this requires making the entire `OGImageRoute()` method async, so users upgrading will need to add an `await` to their code to make this work. This also means all `getImageOptions()` calls are done up front which _may_ be slightly slower in dev potentially, but OG images are not used much in dev, so the impact shouldn’t be too bad. Future optimisations could be made to the scheduling there if we hear feedback that the `Promise.all()` used currently is problematic.

An alternative considered would be to move `format` up to a top-level option rather than setting it in `getImageOptions()`, but making things async and dynamic like this is more flexible and the one-time migration cost is not too bad I think.