### PR TITLE
feat: allow layer order to be changed

### DIFF
--- a/demo/src/pages/background-test/[path].ts
+++ b/demo/src/pages/background-test/[path].ts
@@ -62,6 +62,16 @@ export const { getStaticPaths, GET } = await OGImageRoute({
       title: 'bgImage: {\n  position: ["end", "center"],\n}',
       font: { title: { color: [0, 0, 0], weight: 'Bold' } },
     },
+    'layer-test.md': {
+      bgImage: { path: bgPath, fit: 'fill' },
+      title: 'bgImage: { fit: "fill" }',
+      border: {
+        color: [255, 0, 0],
+        width: 10,
+        side: 'inline-start',
+      },
+      layerOrder: ['bgImage', 'border', 'logo'],
+    },
   } satisfies Record<string, Partial<OGImageOptions>>,
   getImageOptions: (_path, { title, ...page }) => ({
     title: title || '',
@@ -73,6 +83,7 @@ export const { getStaticPaths, GET } = await OGImageRoute({
       [0, 0, 255],
     ],
     font: { title: { color: [0, 255, 0], weight: 'Bold' } },
+    cacheDir: false,
     ...page,
   }),
 });

--- a/demo/src/pages/background-test/index.md
+++ b/demo/src/pages/background-test/index.md
@@ -21,6 +21,7 @@ This test loads a background image with various settings.
   <img alt="Example image" src="/background-test/logo-end.png">
   <img alt="Example image" src="/background-test/logo-center-end.png">
   <img alt="Example image" src="/background-test/logo-end-center.png">
+  <img alt="Example image" src="/background-test/layer-test.png">
 </div>
 
 - [Home](/)

--- a/packages/astro-og-canvas/src/generateOpenGraphImage.ts
+++ b/packages/astro-og-canvas/src/generateOpenGraphImage.ts
@@ -85,6 +85,7 @@ export async function generateOpenGraphImage({
   fonts = ['https://api.fontsource.org/v1/fonts/noto-sans/latin-400-normal.ttf'],
   format = 'PNG',
   quality = 90,
+  layerOrder = ['border', 'bgImage', 'logo'],
 }: OGImageOptions): Promise<BodyInit> {
   // Load and configure font families.
   const fontMgr = await fontManager.get(fonts);
@@ -108,7 +109,7 @@ export async function generateOpenGraphImage({
       loadedLogo?.hash,
       loadedBg?.hash,
       fonts.map((font) => fontManager.getHash(font)),
-    ])
+    ]),
   );
 
   let cacheFilePath: string | undefined;
@@ -156,96 +157,109 @@ export async function generateOpenGraphImage({
       [0, height],
       bgGradient.map((rgb) => CanvasKit.Color(...rgb)),
       null,
-      CanvasKit.TileMode.Clamp
-    )
+      CanvasKit.TileMode.Clamp,
+    ),
   );
   canvas.drawRect(bgRect, bgPaint);
 
-  // Draw border.
-  if (border.width) {
-    const borderStyle = new CanvasKit.Paint();
-    borderStyle.setStyle(CanvasKit.PaintStyle.Stroke);
-    borderStyle.setColor(CanvasKit.Color(...border.color));
-    borderStyle.setStrokeWidth(border.width * 2);
-    const borders: Record<LogicalSide, XYWH> = {
-      'block-start': edges.top,
-      'block-end': edges.bottom,
-      'inline-start': isRtl ? edges.right : edges.left,
-      'inline-end': isRtl ? edges.left : edges.right,
-    };
-    canvas.drawLine(...borders[border.side], borderStyle);
-  }
-
-  // Draw background image.
-  if (bgImage && loadedBg?.buffer) {
-    const bgImg = CanvasKit.MakeImageFromEncoded(loadedBg.buffer);
-    if (bgImg) {
-      let { position = 'center', fit = 'none' } = bgImage;
-      if (typeof position === 'string') position = [position, position];
-
-      const [bgW, bgH] = [bgImg.width(), bgImg.height()];
-      let [targetW, targetH] = [bgW, bgH];
-      if (fit === 'fill') {
-        [targetW, targetH] = [width, height];
-      } else if (fit === 'cover') {
-        const ratio = bgW / width < bgH / height ? width / bgW : height / bgH;
-        [targetW, targetH] = [bgW * ratio, bgH * ratio];
-      } else if (fit === 'contain') {
-        const ratio = bgW / width > bgH / height ? width / bgW : height / bgH;
-        [targetW, targetH] = [bgW * ratio, bgH * ratio];
-      }
-
-      const [blockAlign, inlineAlign] = position;
-      const targetX =
-        inlineAlign === 'start'
-          ? 0
-          : inlineAlign === 'end'
-          ? width - targetW
-          : (width - targetW) / 2;
-      const targetY =
-        blockAlign === 'start'
-          ? 0
-          : blockAlign === 'end'
-          ? height - targetH
-          : (height - targetH) / 2;
-
-      // Draw image
-      const srcRect = CanvasKit.XYWHRect(0, 0, bgW, bgH);
-      const destRect = CanvasKit.XYWHRect(targetX, targetY, targetW, targetH);
-      canvas.drawImageRect(bgImg, srcRect, destRect, new CanvasKit.Paint());
-    }
-  }
-
-  // Draw logo.
   let logoHeight = 0;
-  if (logo && loadedLogo?.buffer) {
-    const img = CanvasKit.MakeImageFromEncoded(loadedLogo.buffer);
-    if (img) {
-      const logoH = img.height();
-      const logoW = img.width();
-      const targetW = logo.size?.[0] ?? logoW;
-      const targetH = logo.size?.[1] ?? (targetW / logoW) * logoH;
-      const xRatio = targetW / logoW;
-      const yRatio = targetH / logoH;
-      logoHeight = targetH;
 
-      // Matrix transform to scale the logo to the desired size.
-      const imagePaint = new CanvasKit.Paint();
-      imagePaint.setImageFilter(
-        CanvasKit.ImageFilter.MakeMatrixTransform(
-          CanvasKit.Matrix.scaled(xRatio, yRatio),
-          { filter: CanvasKit.FilterMode.Linear },
-          null
-        )
-      );
+  const layerFunctions: { [fnName: string]: () => void } = {
+    border: () => {
+      // Draw border.
+      if (border.width) {
+        const borderStyle = new CanvasKit.Paint();
+        borderStyle.setStyle(CanvasKit.PaintStyle.Stroke);
+        borderStyle.setColor(CanvasKit.Color(...border.color));
+        borderStyle.setStrokeWidth(border.width * 2);
+        const borders: Record<LogicalSide, XYWH> = {
+          'block-start': edges.top,
+          'block-end': edges.bottom,
+          'inline-start': isRtl ? edges.right : edges.left,
+          'inline-end': isRtl ? edges.left : edges.right,
+        };
+        canvas.drawLine(...borders[border.side], borderStyle);
+      }
+    },
+    bgImage: () => {
+      // Draw background image.
+      if (bgImage && loadedBg?.buffer) {
+        const bgImg = CanvasKit.MakeImageFromEncoded(loadedBg.buffer);
+        if (bgImg) {
+          let { position = 'center', fit = 'none' } = bgImage;
+          if (typeof position === 'string') position = [position, position];
 
-      const imageLeft = isRtl
-        ? (1 / xRatio) * (width - margin['inline-start']) - logoW
-        : (1 / xRatio) * margin['inline-start'];
+          const [bgW, bgH] = [bgImg.width(), bgImg.height()];
+          let [targetW, targetH] = [bgW, bgH];
+          if (fit === 'fill') {
+            [targetW, targetH] = [width, height];
+          } else if (fit === 'cover') {
+            const ratio = bgW / width < bgH / height ? width / bgW : height / bgH;
+            [targetW, targetH] = [bgW * ratio, bgH * ratio];
+          } else if (fit === 'contain') {
+            const ratio = bgW / width > bgH / height ? width / bgW : height / bgH;
+            [targetW, targetH] = [bgW * ratio, bgH * ratio];
+          }
 
-      canvas.drawImage(img, imageLeft, (1 / yRatio) * margin['block-start'], imagePaint);
+          const [blockAlign, inlineAlign] = position;
+          const targetX =
+            inlineAlign === 'start'
+              ? 0
+              : inlineAlign === 'end'
+                ? width - targetW
+                : (width - targetW) / 2;
+          const targetY =
+            blockAlign === 'start'
+              ? 0
+              : blockAlign === 'end'
+                ? height - targetH
+                : (height - targetH) / 2;
+
+          // Draw image
+          const srcRect = CanvasKit.XYWHRect(0, 0, bgW, bgH);
+          const destRect = CanvasKit.XYWHRect(targetX, targetY, targetW, targetH);
+          canvas.drawImageRect(bgImg, srcRect, destRect, new CanvasKit.Paint());
+        }
+      }
+    },
+    logo: () => {
+      // Draw logo.
+      if (logo && loadedLogo?.buffer) {
+        const img = CanvasKit.MakeImageFromEncoded(loadedLogo.buffer);
+        if (img) {
+          const logoH = img.height();
+          const logoW = img.width();
+          const targetW = logo.size?.[0] ?? logoW;
+          const targetH = logo.size?.[1] ?? (targetW / logoW) * logoH;
+          const xRatio = targetW / logoW;
+          const yRatio = targetH / logoH;
+          logoHeight = targetH;
+
+          // Matrix transform to scale the logo to the desired size.
+          const imagePaint = new CanvasKit.Paint();
+          imagePaint.setImageFilter(
+            CanvasKit.ImageFilter.MakeMatrixTransform(
+              CanvasKit.Matrix.scaled(xRatio, yRatio),
+              { filter: CanvasKit.FilterMode.Linear },
+              null,
+            ),
+          );
+
+          const imageLeft = isRtl
+            ? (1 / xRatio) * (width - margin['inline-start']) - logoW
+            : (1 / xRatio) * margin['inline-start'];
+
+          canvas.drawImage(img, imageLeft, (1 / yRatio) * margin['block-start'], imagePaint);
+        }
+      }
+    },
+  };
+
+  layerOrder.forEach((fn) => {
+    if (layerFunctions[fn]) {
+      layerFunctions[fn]();
     }
-  }
+  });
 
   if (fontMgr) {
     // Create paragraph with initial styles and add title.
@@ -259,7 +273,7 @@ export async function generateOpenGraphImage({
 
     // Add small empty line betwen title & description.
     paragraphBuilder.pushStyle(
-      new CanvasKit.TextStyle({ fontSize: padding / 3, heightMultiplier: 1 })
+      new CanvasKit.TextStyle({ fontSize: padding / 3, heightMultiplier: 1 }),
     );
     paragraphBuilder.addText('\n\n');
 

--- a/packages/astro-og-canvas/src/generateOpenGraphImage.ts
+++ b/packages/astro-og-canvas/src/generateOpenGraphImage.ts
@@ -106,6 +106,7 @@ export async function generateOpenGraphImage({
       fontConfig,
       fonts,
       quality,
+      layerOrder,
       loadedLogo?.hash,
       loadedBg?.hash,
       fonts.map((font) => fontManager.getHash(font)),

--- a/packages/astro-og-canvas/src/types.ts
+++ b/packages/astro-og-canvas/src/types.ts
@@ -133,4 +133,6 @@ export interface OGImageOptions {
   format?: Exclude<keyof CanvasKit['ImageFormat'], 'values'>;
   /** Image quality between `0` (very lossy) and `100` (least lossy). Not used by all formats. */
   quality?: number;
+  /** Layer Order */
+  layerOrder?: Array<'bgImage' | 'border' | 'logo'>;
 }


### PR DESCRIPTION
I had an issue where the border was invisible because it was drawn onto the canvas before the background image.

I figured my use-case could be fixed by just moving to border code below the background code, but that only solves my use case.

This makes it so the user can control the layer order, and new layers can be easily added. I didn't put the text or base colour background in there as it didn't seem likely that you would ever want your logo to appear infront of the text etc... (not that the spacing would allow that to clip anyway).

The default order leaves the border behind the bgImage, but could easily be changed.